### PR TITLE
chore: add agent symlink setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ That work shapes the opinions in here: heavy use of multi-cloud Terraform, suppl
 | [`multi-agent-comms.md`](multi-agent-comms.md) | Protocol for multiple Claude instances / agents coordinating on the same project. |
 | [`triage.md`](triage.md) | Backlog triage + work selection: 5-dimension labelling (priority/severity/urgency/impact/effort), parallel-agent fan-out, three-pass approach for large backlogs, stale-sweep procedure. |
 | [`commands/`](commands/) | Custom slash commands. |
-| [`scripts/setup-agent-symlinks.sh`](scripts/setup-agent-symlinks.sh) | Recreate or update symlinked guidance files inside `~/.codex` and `~/.gemini` so each file points back to the shared guidance files. |
+| [`scripts/setup-agent-symlinks.sh`](scripts/setup-agent-symlinks.sh) | Recreate or update the symlinked guidance files inside `~/.codex` and `~/.gemini` so each file points back to the shared guidance files. |
 | [`agents/`](agents/) | Submodule pointing to [`contains-studio/agents`](https://github.com/contains-studio/agents) — a curated agent library. |
 | [`local-paths.md.example`](local-paths.md.example) | Template for `local-paths.md`, per-machine paths and tool locations referenced from the rule files (e.g. graphify CLI / venv). |
 | [`projects.md.example`](projects.md.example) | Template for `projects.md`, the personal index of projects Claude should know about. |

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ That work shapes the opinions in here: heavy use of multi-cloud Terraform, suppl
 | [`multi-agent-comms.md`](multi-agent-comms.md) | Protocol for multiple Claude instances / agents coordinating on the same project. |
 | [`triage.md`](triage.md) | Backlog triage + work selection: 5-dimension labelling (priority/severity/urgency/impact/effort), parallel-agent fan-out, three-pass approach for large backlogs, stale-sweep procedure. |
 | [`commands/`](commands/) | Custom slash commands. |
+| [`scripts/setup-agent-symlinks.sh`](scripts/setup-agent-symlinks.sh) | Recreate the `~/.codex` and `~/.gemini` symlinks that point back to these shared guidance files. |
 | [`agents/`](agents/) | Submodule pointing to [`contains-studio/agents`](https://github.com/contains-studio/agents) — a curated agent library. |
 | [`local-paths.md.example`](local-paths.md.example) | Template for `local-paths.md`, per-machine paths and tool locations referenced from the rule files (e.g. graphify CLI / venv). |
 | [`projects.md.example`](projects.md.example) | Template for `projects.md`, the personal index of projects Claude should know about. |
@@ -57,6 +58,11 @@ That work shapes the opinions in here: heavy use of multi-cloud Terraform, suppl
    All three are gitignored, so edits stay local.
 
 4. **Restore anything you need** from the backup (e.g. `plugins/`, `projects/`, `sessions/`).
+
+5. **Expose these instructions to Codex and Gemini CLI:**
+   ```bash
+   ~/.claude/scripts/setup-agent-symlinks.sh
+   ```
 
 ## Customizing
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ That work shapes the opinions in here: heavy use of multi-cloud Terraform, suppl
 | [`multi-agent-comms.md`](multi-agent-comms.md) | Protocol for multiple Claude instances / agents coordinating on the same project. |
 | [`triage.md`](triage.md) | Backlog triage + work selection: 5-dimension labelling (priority/severity/urgency/impact/effort), parallel-agent fan-out, three-pass approach for large backlogs, stale-sweep procedure. |
 | [`commands/`](commands/) | Custom slash commands. |
-| [`scripts/setup-agent-symlinks.sh`](scripts/setup-agent-symlinks.sh) | Recreate the `~/.codex` and `~/.gemini` symlinks that point back to these shared guidance files. |
+| [`scripts/setup-agent-symlinks.sh`](scripts/setup-agent-symlinks.sh) | Recreate or update symlinked guidance files inside `~/.codex` and `~/.gemini` so each file points back to the shared guidance files. |
 | [`agents/`](agents/) | Submodule pointing to [`contains-studio/agents`](https://github.com/contains-studio/agents) — a curated agent library. |
 | [`local-paths.md.example`](local-paths.md.example) | Template for `local-paths.md`, per-machine paths and tool locations referenced from the rule files (e.g. graphify CLI / venv). |
 | [`projects.md.example`](projects.md.example) | Template for `projects.md`, the personal index of projects Claude should know about. |

--- a/scripts/setup-agent-symlinks.sh
+++ b/scripts/setup-agent-symlinks.sh
@@ -66,6 +66,11 @@ link_one() {
   target="$1"
   link_path="$2"
 
+  if [ ! -e "$target" ]; then
+    echo "error: target does not exist: $target" >&2
+    return 1
+  fi
+
   if [ -e "$link_path" ] && [ ! -L "$link_path" ]; then
     echo "error: refusing to overwrite non-symlink: $link_path" >&2
     return 1

--- a/scripts/setup-agent-symlinks.sh
+++ b/scripts/setup-agent-symlinks.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: setup-agent-symlinks.sh [--home DIR] [--claude-dir DIR]
+
+Create or update Codex and Gemini symlinks to the shared Claude guidance files.
+
+Options:
+  --home DIR        Home directory containing .codex and .gemini (default: $HOME)
+  --claude-dir DIR  Claude config directory to link to (default: HOME/.claude)
+  -h, --help        Show this help.
+
+The script is idempotent. It updates existing symlinks, creates missing symlinks,
+and refuses to overwrite regular files or directories.
+USAGE
+}
+
+home_dir="${HOME:?HOME is not set}"
+claude_dir=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --home)
+      if [ "$#" -lt 2 ]; then
+        echo "error: --home requires a directory" >&2
+        exit 2
+      fi
+      home_dir="$2"
+      shift 2
+      ;;
+    --claude-dir)
+      if [ "$#" -lt 2 ]; then
+        echo "error: --claude-dir requires a directory" >&2
+        exit 2
+      fi
+      claude_dir="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$claude_dir" ]; then
+  claude_dir="$home_dir/.claude"
+fi
+
+if [ ! -d "$claude_dir" ]; then
+  echo "error: Claude config directory does not exist: $claude_dir" >&2
+  exit 1
+fi
+
+codex_dir="$home_dir/.codex"
+gemini_dir="$home_dir/.gemini"
+
+link_one() {
+  target="$1"
+  link_path="$2"
+
+  if [ -e "$link_path" ] && [ ! -L "$link_path" ]; then
+    echo "error: refusing to overwrite non-symlink: $link_path" >&2
+    return 1
+  fi
+
+  if [ -L "$link_path" ]; then
+    current_target="$(readlink "$link_path")"
+    if [ "$current_target" = "$target" ]; then
+      echo "ok: $link_path -> $target"
+      return 0
+    fi
+    ln -sfn "$target" "$link_path"
+    echo "updated: $link_path -> $target"
+    return 0
+  fi
+
+  ln -s "$target" "$link_path"
+  echo "created: $link_path -> $target"
+}
+
+link_shared_docs() {
+  agent_dir="$1"
+  mkdir -p "$agent_dir"
+
+  link_one "$claude_dir/CLAUDE.md" "$agent_dir/AGENTS.md"
+  link_one "$claude_dir/coding-standards.md" "$agent_dir/coding-standards.md"
+  link_one "$claude_dir/conventions.md" "$agent_dir/conventions.md"
+  link_one "$claude_dir/git-workflow.md" "$agent_dir/git-workflow.md"
+  link_one "$claude_dir/infra-ops.md" "$agent_dir/infra-ops.md"
+  link_one "$claude_dir/local-paths.md" "$agent_dir/local-paths.md"
+  link_one "$claude_dir/multi-agent-comms.md" "$agent_dir/multi-agent-comms.md"
+  link_one "$claude_dir/project-docs.md" "$agent_dir/project-docs.md"
+  link_one "$claude_dir/projects.md" "$agent_dir/projects.md"
+  link_one "$claude_dir/tool-usage.md" "$agent_dir/tool-usage.md"
+  link_one "$claude_dir/triage.md" "$agent_dir/triage.md"
+}
+
+link_shared_docs "$codex_dir"
+link_shared_docs "$gemini_dir"
+link_one "$claude_dir/CLAUDE.md" "$gemini_dir/GEMINI.md"


### PR DESCRIPTION
## Summary

- add `scripts/setup-agent-symlinks.sh` to recreate Codex and Gemini CLI symlinks back to `~/.claude`
- document the script in the README setup flow

## Verification

- `bash -n scripts/setup-agent-symlinks.sh`
- `/tmp/claude/verify-setup-agent-symlinks.sh`
- `scripts/setup-agent-symlinks.sh`
- `pre-commit run --all-files`

Follow-up issues filed: none — confirmed against the exit checklist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * README updated with a final setup step instructing users to run the new setup utility after restoring backed-up state so local agent CLIs can access guidance.

* **New Features**
  * Added an executable setup utility that idempotently creates/updates symlinks for shared agent guidance across local agent environments; it verifies targets, preserves non-symlink files, updates mismatched links, ensures needed directories exist, and creates an alternate-agent guidance link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->