### PR TITLE
chore: gitignore RTK.md and *.bak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,11 @@ local-paths.md
 projects.md
 settings.json
 
+# Personal tooling integration docs (e.g. RTK / Rust Token Killer) — not portable to forks
+RTK.md
+
+# Editor / shell / settings backups — never tracked
+*.bak
+
 # macOS junk
 .DS_Store


### PR DESCRIPTION
## Summary

Two additions to `.gitignore` for personal-tooling artefacts that shouldn't be tracked in a config repo meant for forking:

- **`RTK.md`** — integration docs for the local RTK (Rust Token Killer) CLI proxy. Anyone forking this repo without RTK installed would be misled by these instructions; the doc is local-only. Pairs naturally with the existing `settings.json` rule (the RTK hook lives in personal `settings.json`, not in the committed `settings.example.json`).
- **`*.bak`** — editor/shell backup files. Never want them in history. Catches `settings.json.bak` etc. that accumulate over time.

Both untracked files were sitting in the working tree at the time of this PR — adding them to `.gitignore` keeps them out of \`git status\` noise and prevents accidental staging.

## Test plan

- [ ] \`git check-ignore -v RTK.md settings.json.bak\` from \`~/.claude\` returns the new \`.gitignore\` rules
- [ ] \`git status\` no longer shows either file as untracked
- [ ] \`git diff --stat origin/main\` shows exactly one file changed (\`.gitignore\`), 6 insertions, 0 deletions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to exclude additional file types from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->