### PR TITLE
chore: gitignore runtime team inboxes and cleanup marker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,10 @@ file-history/
 shell-snapshots/
 session-env/
 agent-comms/
+teams/
 telemetry/
 statsig/
+.last-cleanup
 
 # Per-session caches and logs
 cache/


### PR DESCRIPTION
Adds `teams/` (multi-agent team inbox data, e.g. `cr-watch-*.json`) and `.last-cleanup` (per-machine cleanup timestamp) to `.gitignore`. Both are per-machine runtime state, not portable repo content, matching the existing `agent-comms/` pattern. No tracked files affected.