### PR TITLE
chore: point agents submodule at cristim/agents fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "agents"]
 	path = agents
-	url = https://github.com/contains-studio/agents.git
+	url = https://github.com/cristim/agents.git


### PR DESCRIPTION
Track the personal fork `cristim/agents` instead of `contains-studio/agents` directly, so local customizations persist regardless of upstream.

- Updates `.gitmodules` URL to the fork.
- Bumps the `agents` gitlink to the fork commit that adds Gemini to the AI-provider lists (`engineering/ai-engineer.md`, `engineering/rapid-prototyper.md`, `testing/tool-evaluator.md`).

A PR proposing the same Gemini addition upstream to contains-studio/agents is opened separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/dotclaude/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->