### PR TITLE
docs(git-workflow): add "CR pattern memory" loop section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,7 @@ Full rules in `~/.claude/tool-usage.md` — **read before any Bash call or scrip
 - After ANY correction: save the lesson to auto-memory (`~/.claude/projects/<project>/memory/`) as a rule that prevents the same mistake.
 - **Memory entry structure**: lead with the rule or fact, then a **Why:** line (reason or past incident) and a **How to apply:** line (when it triggers). Knowing *why* lets you judge edge cases.
 - **Before creating an entry, search existing memories** — prefer updating over duplicating. **Remove stale entries promptly.** Review lessons at session start for the relevant project.
+- **Apply per-project memory at write time and review gates, not only after CR.** Project `feedback_*.md` entries (`~/.claude/projects/<project-slug>/memory/`) encode agreed patterns from prior CR rounds. Read them in four contexts, highest-leverage first: while writing new code; during the §1 pre-commit and post-impl 3-pass review gates; and before pushing CR-fix commits. Write-side schema + quality bar live in `git-workflow.md`'s "Per-project feedback memory" section.
 - **Workflow improvements**: when you notice a rule in `CLAUDE.md` or any linked file could be improved (missing guidance, ambiguous wording, outdated advice, a gap that just caused a problem), **proactively propose the change** and wait for approval before editing. Applies equally to project-level `CLAUDE.md` files.
 
 ### 4. Verification Before Done

--- a/git-workflow.md
+++ b/git-workflow.md
@@ -280,6 +280,16 @@ File follow-up issues for out-of-scope items
 
 All four watcher classes (`cr-watch-*`, `ci-watch-*`, `merge-watch-*`, plus any project-specific deploy-watch) run in background — the main session never blocks on PR review and continues with the next task.
 
+## CR pattern memory
+
+When CodeRabbit finishes its review pass on any PR, before pushing fix commits, scan the per-project `memory/` directory (under `~/.claude/projects/<project-slug>/memory/`) and apply any matching `feedback_*.md` rules to the branch proactively. This catches patterns that were previously flagged and agreed upon before CR raises them again.
+
+After all CR findings from a given pass are addressed, evaluate each one: if it represents a recurring class of issue (style / idiom / cross-cutting concern -- NOT a one-off PR-specific bug), write a new `feedback_<slug>.md` entry following the schema in that project's `MEMORY.md`. Before creating a new file, search existing entries to avoid duplicates -- prefer updating the `**Why:**` line of an existing entry with the new PR citation rather than creating a parallel entry.
+
+The quality bar for a new memory entry: a clear one-line rule + a `**Why:**` with at least one PR citation + a `**How to apply:**` that names the concrete code location or pattern to scan for. Entries that are too vague to trigger a specific check are not useful. One-off PR-specific bugs (a typo, a logic error unique to this PR's feature, a test fixture that was just wrong) do not qualify.
+
+This keeps the memory garden growing and prevents the same nit from being raised in every future PR that touches the same code surface.
+
 ## Hooks & docs
 
 - **Pre-commit hooks**: projects must have hooks for linting, formatting, and tests. Never skip with `--no-verify`.

--- a/git-workflow.md
+++ b/git-workflow.md
@@ -280,15 +280,22 @@ File follow-up issues for out-of-scope items
 
 All four watcher classes (`cr-watch-*`, `ci-watch-*`, `merge-watch-*`, plus any project-specific deploy-watch) run in background — the main session never blocks on PR review and continues with the next task.
 
-## CR pattern memory
+## Per-project feedback memory
 
-When CodeRabbit finishes its review pass on any PR, before pushing fix commits, scan the per-project `memory/` directory (under `~/.claude/projects/<project-slug>/memory/`) and apply any matching `feedback_*.md` rules to the branch proactively. This catches patterns that were previously flagged and agreed upon before CR raises them again.
+Every project has a memory garden at `~/.claude/projects/<project-slug>/memory/` containing `feedback_*.md` entries -- transferable patterns that have been agreed upon (often via prior CR rounds, sometimes filed proactively). Each entry encodes: a one-line rule, a `**Why:**` line with a PR citation, and a `**How to apply:**` line naming the concrete code location or scan pattern.
 
-After all CR findings from a given pass are addressed, evaluate each one: if it represents a recurring class of issue (style / idiom / cross-cutting concern -- NOT a one-off PR-specific bug), write a new `feedback_<slug>.md` entry following the schema in that project's `MEMORY.md`. Before creating a new file, search existing entries to avoid duplicates -- prefer updating the `**Why:**` line of an existing entry with the new PR citation rather than creating a parallel entry.
+**Read the memory garden in four contexts:**
+
+1. **Before / during writing new code on any branch.** Skim relevant `feedback_*.md` entries up front and apply them proactively. Catches patterns at write-time and saves a downstream CR cycle. This is the cheapest place to apply a known rule.
+2. **During the §1 pre-commit 3-pass review gate.** Use the memory as one input to the checklist alongside Completeness / Correctness / Security / Bugs / Duplication. Any pattern that matches the changeset should be cross-checked.
+3. **During the §1 post-implementation review gate.** Same usage -- the memory is a fast checklist source the reviewer can apply alongside the other dimensions.
+4. **Before pushing CR-fix commits.** After CodeRabbit lands a review pass, scan the memory before pushing fixes to catch any other matching entries CR might raise next round.
+
+**Write to the memory garden after any CR review pass.** Evaluate each addressed finding: if it represents a recurring class of issue (style / idiom / cross-cutting concern -- NOT a one-off PR-specific bug), write a new `feedback_<slug>.md` entry following the schema in that project's `MEMORY.md`. Before creating a new file, search existing entries to avoid duplicates -- prefer updating the `**Why:**` line of an existing entry with the new PR citation over creating a parallel entry.
 
 The quality bar for a new memory entry: a clear one-line rule + a `**Why:**` with at least one PR citation + a `**How to apply:**` that names the concrete code location or pattern to scan for. Entries that are too vague to trigger a specific check are not useful. One-off PR-specific bugs (a typo, a logic error unique to this PR's feature, a test fixture that was just wrong) do not qualify.
 
-This keeps the memory garden growing and prevents the same nit from being raised in every future PR that touches the same code surface.
+This keeps the memory garden growing AND used. The biggest leverage is the write-time application (context 1) -- catching the issue before it ships, not after CR raises it.
 
 ## Hooks & docs
 


### PR DESCRIPTION
## Summary

Adds a "CR pattern memory" loop section to `git-workflow.md` codifying the per-project memory garden pattern: scan `~/.claude/projects/<project-slug>/memory/` for `feedback_*.md` entries before pushing CR-fix commits, and write a new entry for each addressed finding that represents a recurring style / idiom / cross-cutting concern (not one-off PR-specific bugs).

The pattern was just shaken out on `LeanerCloud/CUDly` via a ~300-PR / 35k-line CR-corpus mining pass; 23 new `feedback_*.md` entries landed there covering Go concurrency, test discipline, auth/security, type/value handling, HTTP semantics, ops/CI, and frontend patterns. The git-workflow.md section formalizes the read+write loop so future sessions on any project automatically use + maintain its memory.

## What changed

`git-workflow.md` — new "## CR pattern memory" section (10 lines) right before "## Hooks & docs". Covers:

- **Read path**: after CR review pass, before fix commits, scan project memory + apply matching rules
- **Write path**: after addressing CR findings, evaluate each one; write a new `feedback_*.md` entry for transferable patterns
- **Quality bar**: rule + Why + How to apply, with PR citations; deduplicate by updating existing entries' Why lines
- **Carve-out**: one-off PR-specific bugs don't qualify; only recurring style / idiom / cross-cutting concerns

## Why

CodeRabbit raises the same small nits across many PRs (e.g. `bytes.NewReader` vs `strings.NewReader(string(bs))`, `time.Sleep` ignoring ctx, missing `t.Cleanup(...AssertExpectations)`, etc.). Without a memory of agreed-upon patterns, each PR re-litigates them. The per-project `memory/` garden + the CR-pattern read/write loop here turns each CR pass into compounding leverage.

## Cross-references

- Proof-of-concept output on `LeanerCloud/CUDly`: 23 `feedback_*.md` entries in `~/.claude/projects/<CUDly-slug>/memory/`
- Companion change on CUDly: project-level `CLAUDE.md` directs agents to the project memory garden before opening PRs there
- Doesn't conflict with PR #17 (which slims CLAUDE.md and strengthens review loops); they touch the same file but different sections

## Test plan

- [x] Manual: `git diff main..HEAD -- git-workflow.md` shows only the new section, no other touched lines
- [ ] Soak: next CR-fix cycle on any project should pick up the read+write loop from this section


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal development process guidance regarding project memory management and self-improvement procedures.

**Note:** This release contains no end-user-facing changes. Updates are limited to internal developer documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/dotclaude/pull/20?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->