### PR TITLE
docs: close pre-commit-vs-CR gap (§1 dimension 6 + /review-staged-diff command + opt-in pre-push hook)

### DIFF
--- a/commands/review-staged-diff.md
+++ b/commands/review-staged-diff.md
@@ -1,0 +1,38 @@
+Run a CR-style review of the staged diff against `git-workflow.md` §1's six dimensions PLUS this project's `feedback_*.md` memory garden. Goal: catch what CodeRabbit would catch, BEFORE the commit lands, so the post-push CR loop converges in one pass.
+
+**Inputs to gather first** (in this order):
+
+1. `git diff --cached` — the staged changeset under review. If empty, also try `git diff HEAD..HEAD~1` to review the most recent commit instead and tell the user that's what you're doing.
+2. `ls ~/.claude/projects/<project-slug>/memory/feedback_*.md` — the per-project memory garden. Resolve `<project-slug>` from the working directory + the format in `~/.claude/CLAUDE.md` §3. Read the entries whose names hint at relevance to the diff (e.g. if the diff is Go code, read the `feedback_*go*` and any concurrency/context entries; if Terraform, read the `feedback_tf_*` entries).
+3. The project's `CLAUDE.md` (root or `~/.claude/projects/<slug>/CLAUDE.md`) — for project-specific overrides.
+
+**Per-dimension pass** (read the full staged diff with each lens; do not parallelise within a single pass — humans + CR review serially across dimensions, so do the same):
+
+| Dimension | What to check |
+|---|---|
+| **Completeness** | Does the diff deliver what its commit message claims? Tests updated for the new behaviour? All touched files consistent? |
+| **Correctness** | Logic errors, off-by-ones, wrong assumptions, broken invariants, stale references, type mismatches, leftover debug code, unused imports? |
+| **Security** | Injection, auth bypass, secrets exposure, missing input validation, OWASP top 10? |
+| **Bugs** | Race conditions, null derefs, edge cases, resource leaks, error handling gaps, broken tests, stale mocks? |
+| **Duplication** | Does any new helper replicate logic that already exists in the project? Grep for distinctive identifiers from the new code. |
+| **Memory garden match** | For each `feedback_*.md` entry whose `**How to apply:**` matches the changeset, verify the diff conforms. Cite the entry name when reporting a match. |
+
+**Findings table format**:
+
+```
+| # | Severity | Dimension | File:Line | Finding | Suggested fix |
+|---|---|---|---|---|---|
+| 1 | Major | Bugs | foo.go:42 | nil deref when X | guard with `if x != nil` before access |
+```
+
+Severity: Major (would break behaviour or hide a bug), Minor (style / nitpick), Info (worth flagging but not blocking). One row per finding; do not bundle.
+
+**Fan-out for substantial diffs**: if the staged diff touches more than one of (Go, TypeScript, Terraform, frontend HTML/CSS, SQL/migration, IaC, Docker), or exceeds ~400 lines, spawn the specialised review agents from `git-workflow.md` §"Delegation" in parallel (silent-failure-hunter, type-design-analyzer, pr-test-analyzer, comment-analyzer, code-simplifier) and compile their findings into the same table. Otherwise inline the review.
+
+**Output**:
+
+1. The findings table (or "No issues found" if clean).
+2. A short summary: dimension counts, memory-garden entries that matched, total Major / Minor / Info.
+3. If any finding suggests memorialising a new pattern (a recurring class CR has not yet flagged but is generalisable), call it out at the end so the human can decide whether to add it to memory after the commit lands per `git-workflow.md` §"Per-project feedback memory".
+
+Do NOT modify the staged diff yourself; this command is a review pass, not an edit pass. The user reviews the findings, fixes locally, and re-runs the command until 3 consecutive runs return "No issues found" (the §1 three-clean-pass gate).

--- a/commands/review-staged-diff.md
+++ b/commands/review-staged-diff.md
@@ -2,7 +2,7 @@ Run a CR-style review of the staged diff against `git-workflow.md` §1's six dim
 
 **Inputs to gather first** (in this order):
 
-1. `git diff --cached` — the staged changeset under review. If empty, also try `git diff HEAD..HEAD~1` to review the most recent commit instead and tell the user that's what you're doing.
+1. `git diff --cached` — the staged changeset under review. If empty, also try `git diff HEAD~1..HEAD` to review the most recent commit instead and tell the user that's what you're doing.
 2. `ls ~/.claude/projects/<project-slug>/memory/feedback_*.md` — the per-project memory garden. Resolve `<project-slug>` from the working directory + the format in `~/.claude/CLAUDE.md` §3. Read the entries whose names hint at relevance to the diff (e.g. if the diff is Go code, read the `feedback_*go*` and any concurrency/context entries; if Terraform, read the `feedback_tf_*` entries).
 3. The project's `CLAUDE.md` (root or `~/.claude/projects/<slug>/CLAUDE.md`) — for project-specific overrides.
 

--- a/git-workflow.md
+++ b/git-workflow.md
@@ -48,6 +48,9 @@ Read the full staged diff (`git diff --cached`) and the relevant unstaged contex
 - **Security**: Any injection vectors, auth bypasses, secrets exposure, missing input validation, OWASP top 10 violations?
 - **Bugs**: Race conditions, null derefs, edge cases, resource leaks, error handling gaps, broken tests, stale mocks?
 - **Duplication**: Does any new function/type/helper in this diff replicate logic that already exists in the project? Grep for distinctive identifiers, constants, or phrases from the new code to catch near-duplicates. If a duplicate is found, stop and either reuse the existing code or refactor it to cover both cases (per `CLAUDE.md` step 1a) — do NOT commit parallel copies.
+- **Memory garden match**: Scan the per-project memory at `~/.claude/projects/<project-slug>/memory/feedback_*.md` (and any matching `project_*.md`) and apply every entry whose `**How to apply:**` line matches the changeset. This is the **highest-leverage step** because the entries encode patterns CR already taught us on this project — finding a match here means CR will NOT raise the same nit again. If a finding from the current review surfaces a pattern that's NOT in memory but is generalisable, file the new `feedback_<slug>.md` after the commit lands per §"Per-project feedback memory".
+
+**If CR later finds something this review missed, treat it as a §1 process failure** — not just "CR is a useful second pair of eyes." Either the dimension wasn't checked, the memory-garden scan was skipped, or the specialised reviewer fan-out wasn't dispatched on a substantial diff. Save the lesson (new `feedback_*.md` entry) and tighten the next §1 pass.
 
 ### Each iteration
 

--- a/scripts/pre-push-claude-review.sh
+++ b/scripts/pre-push-claude-review.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# pre-push-claude-review.sh
+#
+# Opt-in git pre-push hook that runs a Sonnet-tier Claude review pass over the
+# diff being pushed before the push proceeds. Catches the same class of issues
+# CodeRabbit would catch on the resulting PR, locally, ~30s.
+#
+# Install:
+#   ln -s ~/.claude/scripts/pre-push-claude-review.sh \
+#         <project>/.git/hooks/pre-push
+#   chmod +x ~/.claude/scripts/pre-push-claude-review.sh
+#
+# Bypass (single push):
+#   SKIP_CLAUDE_REVIEW=1 git push ...
+#
+# Bypass (always for one repo): just remove the symlink.
+#
+# Cost note: this adds ~30s and one Sonnet call per push. Set
+# CLAUDE_REVIEW_MODEL=haiku for a cheaper/faster pass; set
+# CLAUDE_REVIEW_MODEL=opus for the rare diff that warrants the top tier.
+
+set -euo pipefail
+
+if [[ "${SKIP_CLAUDE_REVIEW:-0}" == "1" ]]; then
+  echo "[pre-push-claude-review] SKIP_CLAUDE_REVIEW=1 -> skipping local review pass."
+  exit 0
+fi
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "[pre-push-claude-review] 'claude' CLI not found on PATH -> skipping local review pass."
+  exit 0
+fi
+
+REMOTE_NAME="${1:-origin}"
+MODEL="${CLAUDE_REVIEW_MODEL:-sonnet}"
+
+# stdin lines from git: <local_ref> <local_sha> <remote_ref> <remote_sha>
+# We diff each (remote_sha..local_sha) range and concatenate. If remote_sha is
+# all-zeros (new branch), fall back to merge-base against the remote default
+# branch so the diff isn't the whole history.
+remote_default="$(git remote show "$REMOTE_NAME" 2>/dev/null \
+                  | awk '/HEAD branch/ {print $NF}')"
+remote_default="${remote_default:-main}"
+
+DIFF_FILE="$(mktemp -t claude-pre-push-diff.XXXXXX)"
+trap 'rm -f "$DIFF_FILE"' EXIT
+
+found_any=0
+while read -r local_ref local_sha remote_ref remote_sha; do
+  [[ -z "${local_sha:-}" ]] && continue
+  if [[ "$local_sha" == "0000000000000000000000000000000000000000" ]]; then
+    continue  # deletion -- nothing to review
+  fi
+  if [[ "$remote_sha" == "0000000000000000000000000000000000000000" ]]; then
+    base="$(git merge-base "$local_sha" "$REMOTE_NAME/$remote_default" 2>/dev/null || echo "")"
+    [[ -z "$base" ]] && base="$(git rev-list --max-parents=0 "$local_sha" | head -1)"
+  else
+    base="$remote_sha"
+  fi
+  {
+    printf '\n=== %s..%s (%s) ===\n' "$base" "$local_sha" "$local_ref"
+    git diff "$base..$local_sha"
+  } >> "$DIFF_FILE"
+  found_any=1
+done
+
+if [[ "$found_any" -eq 0 ]]; then
+  echo "[pre-push-claude-review] No diff to review -> skipping."
+  exit 0
+fi
+
+diff_bytes="$(wc -c < "$DIFF_FILE" | tr -d ' ')"
+if [[ "$diff_bytes" -lt 50 ]]; then
+  echo "[pre-push-claude-review] Diff under 50 bytes -> skipping."
+  exit 0
+fi
+
+echo "[pre-push-claude-review] Running $MODEL review on ${diff_bytes} bytes of diff..."
+
+# Find the per-project memory garden if it exists.
+project_slug="$(pwd | sed 's|/|-|g')"
+memory_dir="$HOME/.claude/projects/$project_slug/memory"
+memory_listing=""
+if [[ -d "$memory_dir" ]]; then
+  memory_listing="$(ls "$memory_dir"/feedback_*.md "$memory_dir"/project_*.md 2>/dev/null \
+                    | sed "s|^|- |")"
+fi
+
+PROMPT_FILE="$(mktemp -t claude-pre-push-prompt.XXXXXX)"
+trap 'rm -f "$DIFF_FILE" "$PROMPT_FILE"' EXIT
+
+{
+  cat <<'EOF'
+Run the /review-staged-diff command's logic over the diff below. Apply
+git-workflow.md §1's six dimensions: Completeness, Correctness, Security,
+Bugs, Duplication, Memory-garden match. The memory entries to scan are
+listed below; read the ones whose names match the diff's language/topic
+and report any violation by entry name.
+
+Output ONLY the findings table. If nothing is found, output the literal
+string "REVIEW CLEAN" on a single line. Do NOT summarise or commentate.
+EOF
+  if [[ -n "$memory_listing" ]]; then
+    printf '\nMemory entries for this project:\n%s\n' "$memory_listing"
+  fi
+  printf '\nDiff under review:\n\n'
+  cat "$DIFF_FILE"
+} > "$PROMPT_FILE"
+
+REVIEW_OUTPUT="$(claude -p --model "$MODEL" < "$PROMPT_FILE" 2>&1 || true)"
+
+if [[ -z "${REVIEW_OUTPUT// /}" ]]; then
+  echo "[pre-push-claude-review] Claude returned empty output -> letting push through."
+  exit 0
+fi
+
+if grep -qx 'REVIEW CLEAN' <<< "$REVIEW_OUTPUT"; then
+  echo "[pre-push-claude-review] REVIEW CLEAN -> push proceeding."
+  exit 0
+fi
+
+echo "[pre-push-claude-review] Findings (resolve or set SKIP_CLAUDE_REVIEW=1 to bypass):"
+echo "----------------------------------------------------------------------"
+echo "$REVIEW_OUTPUT"
+echo "----------------------------------------------------------------------"
+exit 1

--- a/scripts/pre-push-claude-review.sh
+++ b/scripts/pre-push-claude-review.sh
@@ -109,7 +109,7 @@ EOF
 
 REVIEW_OUTPUT="$(claude -p --model "$MODEL" < "$PROMPT_FILE" 2>&1 || true)"
 
-if [[ -z "${REVIEW_OUTPUT// /}" ]]; then
+if [[ -z "$(printf '%s' "$REVIEW_OUTPUT" | tr -d '[:space:]')" ]]; then
   echo "[pre-push-claude-review] Claude returned empty output -> letting push through."
   exit 0
 fi


### PR DESCRIPTION
## Summary

Closes the local pre-commit-vs-CR gap surfaced on CUDly PR #684: several CR findings (e.g. `purchasecfg.NewConfig` dropping the caller's `*http.Client.Transport`, mocks losing the deadline-aware ctx contract) could have been caught locally in ~30s by a Sonnet review pass instead of round-tripping through CodeRabbit. This PR codifies "all 3 options" the user authorised:

1. **§1 review gate gets a 6th dimension** — *Memory garden match* — so agents already running the §1 review at write-time also scan the per-project `feedback_*.md` / `project_*.md` entries and apply them. Plus an explicit accountability bullet: "If CR later finds something this review missed, treat it as a §1 process failure" — not just "CR is a useful second pair of eyes." Encoded in `git-workflow.md`.
2. **`/review-staged-diff` Claude command** — the lightweight manual path. The user runs it before `git push`, it runs the same 6-dimension review on the staged diff and outputs a findings table. No edits, just the table — user iterates locally to 3 clean passes.
3. **`scripts/pre-push-claude-review.sh`** — the opt-in automated path. Symlink it into a project's `.git/hooks/pre-push` and every push gets a Sonnet review pass (~30s) before it goes out. `SKIP_CLAUDE_REVIEW=1` bypass, `CLAUDE_REVIEW_MODEL=haiku|sonnet|opus` env var for cost/coverage tradeoff. Reads the per-project memory garden directory and feeds the entry list to the model so the *Memory garden match* dimension actually fires locally.

Complements the merged memory-garden infrastructure from #20.

## Commits

- `1563f3f` docs(git-workflow): add memory-garden scan to §1 per-pass checklist
- `adc154a` docs(commands): add /review-staged-diff command for CR-style local review
- `2e55626` docs(scripts): add opt-in pre-push Claude review hook template

## Test plan

- [x] Three commits land cleanly off `origin/main` with pre-commit hooks passing
- [x] `pre-push-claude-review.sh` is `chmod +x`
- [ ] Wire the pre-push symlink into the CUDly repo and run the next push through it as the live trial — surfaces any rough edges before recommending it more broadly
- [ ] After 2-3 real pushes, capture lessons (false-positive rate, latency, model-tier feel) as a `feedback_*.md` entry in the CUDly memory garden

## Why this is in dotclaude and not project-level

The §1 review gate (dimension 6) is global — same checklist applies in every project. The `/review-staged-diff` command is global because the *logic* is project-agnostic (reads `<project-slug>/memory/feedback_*.md` from the per-project garden). The hook script lives globally and symlinks per-repo, so the source of truth is one place but each repo opts in by symlink. None of this is CUDly-specific — but CUDly is the project where the gap surfaced and where the trial will happen first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated pre-push code review that blocks pushes when issues are found.
  * Memory-based feedback integration that applies project-specific guidance during reviews.

* **Documentation**
  * New step-by-step review guidance covering review dimensions, standardized findings format, and required output sections.
  * Updated workflow to make memory scans and saving missed-feedback mandatory parts of the pre-commit loop.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/dotclaude/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->