### PR TITLE
docs(worktrees): add worktree + branch reclaim sweep after PR merge/close

### DIFF
--- a/worktrees.md
+++ b/worktrees.md
@@ -53,7 +53,7 @@ Paste verbatim below the header — copy-paste, don't paraphrase, so every plan 
 - The CLAUDE.md §1 post-implementation review is clean.
 - **Three consecutive verification passes find no gaps.** A pass covers tests, lint/typecheck, the §4 per-change-type verification (UI smoke, API curl, etc.), and a re-read of the diff against the plan. Any finding → fix and restart the count at zero. Partial credit does not exist.
 
-**On completion**: rebase onto `base_branch:`, push, `git worktree remove` the worktree, flip `status:` to `merged`, then delete (or archive) this plan file.
+**On completion**: rebase onto `base_branch:`, push, `git worktree remove` the worktree, flip `status:` to `merged`, then delete (or archive) this plan file. If the PR merges out-of-band (a human or another agent's `merge-watch` merges it after this session is gone), any later session reclaims this worktree via the sweep in `~/.claude/worktrees.md` ("Reclaiming worktrees after the PR merges or closes").
 
 **On abandonment**: flip `status:` to `abandoned`, clear `pid:`, then remove the worktree and delete the plan file.
 ```
@@ -105,6 +105,40 @@ ALL of these must hold before rebasing/merging back onto the base branch:
 - **Rebase, don't merge, by default**: `git rebase <base-branch>` inside the worktree to keep history linear, then fast-forward the base branch. Use a merge commit only if the base branch protects against force-pushes or the team convention demands it.
 - **After the merge**: push the base branch (triggering the post-push CI watcher per `~/.claude/git-workflow.md`), then `git worktree remove ../<repo>-<slug>`, delete the feature branch if it's no longer needed, and delete the plan file at `~/.claude/projects/<project>/plans/<slug>.md` (or flip its `status:` header to `merged` and move it to a `plans/archive/` subdir if you want an audit trail). Crash-recovery enumeration should only surface active work — stale plan files and worktrees confuse future sessions.
 - **If a worktree is abandoned** (idea didn't pan out, approach superseded): flip the plan's `status:` to `abandoned` before removing the worktree, so recovery doesn't try to resume dead work. Then delete the plan file and worktree as above.
+
+## Reclaiming worktrees after the PR merges or closes (run the sweep)
+
+The creating session is usually **not** the one that observes its PR reach a terminal state: in a PR-based repo, merges happen through GitHub (a human clicking merge, or another agent's `merge-watch`, see `~/.claude/git-workflow.md`), and the creating session may be long dead by then. Likewise a PR can be closed as wontfix/superseded by someone else entirely. So worktree cleanup **cannot** rely only on the creating session's "on completion" step above, or worktrees pile up (a stale `git worktree list` full of merged branches poisons crash-recovery enumeration and wastes disk). Every session treats a worktree whose PR has merged or closed as reclaimable, and sweeps proactively.
+
+**When to sweep** (cheap, so run it liberally):
+- At session start and before ending a session.
+- Immediately after observing any PR merge (yours, or a peer's via `merge-watch`) or any PR you close as wontfix.
+
+**The sweep**: enumerate `git worktree list`, and for each worktree branch resolve its PR state, then reclaim only the terminal + clean ones:
+
+1. **Classify by PR state**: `gh pr list --head <branch> --state all --json number,state,mergedAt` (or `gh pr view <branch>`). Reclaim only when the PR is `MERGED` or `CLOSED` (closed = wontfix/superseded). Leave `OPEN` PRs and any branch with **no** PR (could be pre-PR work) alone.
+2. **Safety gate before removal** (the worktree must be clean and hold nothing unpushed):
+   - `git -C <worktree> status --porcelain` is empty (no uncommitted changes), AND
+   - `git -C <worktree> log --oneline @{u}..` is empty (nothing ahead of upstream); if the upstream branch is already gone from origin, the commits are on the merged PR / base branch.
+   - If **either** check is non-empty, do NOT remove; this is the `feedback_recover_stranded_fix_work` case (a dead agent left finished-but-uncommitted or unpushed work). Recover it first (commit, gate, fresh PR, or cherry-pick), then remove.
+3. **Never reclaim a `locked` worktree** (a running agent owns it) or one whose plan header shows a live PID on this host; coordinate via `~/.claude/agent-comms/` first.
+4. **Remove**: `git worktree remove <worktree>` (add `--force` only if git balks on a lock/submodule *after* the safety gate confirmed it clean). Then delete BOTH sides of the now-orphaned branch and the plan file:
+   - **Local branch**: `git branch -D <branch>`.
+   - **Remote branch**: `git push origin --delete <branch>` — the head branch of a `MERGED` or wontfix-`CLOSED` PR serves no further purpose, and leaving it strands a remote ref that clutters `git branch -r`, breaks branch pickers, and (over a busy repo) accumulates into hundreds of dead refs. Skip only if origin already lacks it (GitHub auto-deleted it on merge — check `git ls-remote --heads origin <branch>` first, or just ignore the "remote ref does not exist" error). NEVER delete the remote of an `OPEN`-PR branch, `main`, or a protected/base branch.
+   - **Plan file**: delete `~/.claude/projects/<project>/plans/<slug>.md` (or flip `status:` to `merged`/`abandoned` and move it to `plans/archive/`).
+
+**Never bulk-remove blindly**: enumerate, classify by PR state, safety-gate each, remove only the confirmed-terminal-and-clean. A worktree that fails the safety gate is a signal (stranded work to recover), not an obstacle to force past.
+
+## Sweep merged/closed branches that have NO worktree
+
+The worktree sweep above only reaches branches that still have a worktree. Local and remote **branch refs outlive their worktrees** — every merged PR leaves a `refs/heads/<branch>` (and often a `refs/remotes/origin/<branch>`) behind, and these pile into the hundreds on a busy repo, poisoning branch pickers and `gh`/`git` autocompletion. So pair the worktree sweep with a **branch sweep** at session start/end (also cheap):
+
+1. **Build the authoritative merged set** — squash-merges mean `git branch --merged` MISSES most merges (the squashed commit has a different SHA), so do NOT gate on it. Use the PR state instead: `gh pr list --state merged --limit 3000 --json headRefName --jq '.[].headRefName' | sort -u > merged.txt`. Build a `closed.txt` the same way for wontfix/superseded closes if you want to sweep those too.
+2. **Compute delete sets by intersection, with hard exclusions**: also fetch the current **open**-PR head branches (`--state open`) and a protected list (`main`, any long-lived base). `local_del = local ∩ merged − open − protected`; `remote_del = origin ∩ merged − open − protected`. Print the counts and explicitly assert the open-PR branches and `main` are absent from both delete sets before deleting anything.
+3. **Delete**: `git branch -D` each local; `git push origin --delete` each remote **in batches** (~25 refs per push) with a few seconds between batches, to stay under GitHub's secondary/abuse rate limit (see `feedback_pace_merges_secondary_ratelimit`). A per-branch fallback handles refs GitHub already auto-deleted without failing the batch.
+4. **Dirty-worktree safety still applies**: if a to-be-deleted branch has a worktree with uncommitted/unpushed work, snapshot it (`git diff HEAD > <preserved-path>.patch`) before removing — never `--force` away un-snapshotted local edits even on a merged branch.
+
+This is exactly the cleanup that keeps a repo from reaching hundreds of stale worktrees/branches; run it as routine hygiene, not a one-off rescue.
 
 ## When to skip
 


### PR DESCRIPTION
Adds a proactive sweep so worktrees and stale branch refs do not pile up when a PR reaches a terminal state in a session other than the one that created the worktree (the common case in a PR-based repo). Covers: worktree reclaim (classify by PR state, safety-gate clean+nothing-unpushed before removal, never touch locked/live worktrees, delete both branch sides + plan file), plus a companion branch sweep for merged/closed branches with no worktree (PR-state as the authoritative merged set since squash-merges defeat `git branch --merged`, hard exclusions for open-PR heads and protected branches, batched remote deletes for the secondary rate limit, dirty-worktree snapshotting).

Pre-existing uncommitted change in the working tree; unrelated to the Opus 5 tier PR (#32).