### PR TITLE
chore(gitignore): ignore daemon and scheduler runtime state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,16 @@ mcp-needs-auth-cache.json
 
 # Per-run security warning state
 security_warnings_state_*.json
+security_warnings_state_*.lock
+
+# Daemon / scheduler runtime state (control key, auth state, logs, job + security state) — never track
+daemon/
+jobs/
+security/
+daemon.log
+daemon-auth-status.json
+daemon-auth-cooldown
+scheduled_tasks.lock
 
 # Per-project memory (persisted per working directory)
 projects/


### PR DESCRIPTION
Ignores per-machine daemon/scheduler runtime artifacts that must never be tracked — including a control key and auth state: daemon/, jobs/, security/, daemon.log, daemon-auth-status.json, daemon-auth-cooldown, scheduled_tasks.lock, and security_warnings_state_*.lock (companion to the already-ignored .json). No tracked files are affected (all currently untracked).