### PR TITLE
docs: make the comment budget measurable and enforceable

### DIFF
--- a/skills/coding-standards/SKILL.md
+++ b/skills/coding-standards/SKILL.md
@@ -189,8 +189,29 @@ Rationale belongs in the PR description; the source carries only what a future e
 - **Default to no comment.** Naming and structure carry the meaning; reach for a comment only where they can't.
 - **Comment only where the WHY isn't deducible from the code**: a deliberate choice a reader would otherwise "fix", a constraint that isn't visible at this spot, a workaround for an external bug (link the upstream issue or CVE), a deviation from the obvious approach.
 - **Keep it terse: 1-2 lines.** Never paragraphs, never half a page. If it needs more than that, it belongs in the PR description or the commit message.
-- **Rough budget: under ~15% comment-to-code on added lines.** A guideline for self-checking, not a hard gate; config files and public API surfaces legitimately run higher.
+- **Two hard per-comment rules**, checkable one comment at a time and not subject to averaging: **no comment exceeds 2 lines**, and **no comment describes what the code does** (that one is deleted, not shortened). These bite where a ratio can't: a diff can sit under budget and still be full of three-line restatements.
+- **Budget: under ~15% comment-to-code on added lines**, measured as below. Over budget is not a veto, it is a trigger — go back through the comments and delete until you are under it or can name why this file is a genuine exception.
 - **Delete on sight**: restatements of the next line; multi-paragraph rationale essays; what-was-considered-and-rejected narrative; references to review rounds, our own past bugs, or `"as of <date>"`; JSDoc/docstrings restating types the signature already gives; long preambles on tests (the test name carries the meaning).
+
+**Measure it the same way every time.** State the number in the PR description or the pre-commit self-check, so it is a fact rather than an impression:
+
+```bash
+git diff <base>...HEAD -- . ':(exclude)**/dist/*' ':(exclude)**/*.lock' | awk '
+  /^\+/ && !/^\+\+\+/ { t++; l=substr($0,2); sub(/^[ \t]+/,"",l)
+    if (l ~ /^(\/\/|\/\*|\*|#)/) c++; if (l=="") b++ }
+  END { printf "added=%d comment=%d code=%d ratio=%.1f%%\n", t, c, t-c-b, c*100/(t-b) }'
+```
+
+Three ways this number lies, all of which have produced a wrong answer in practice:
+- **Whole-file counts instead of added lines.** Counting every comment in a file you touched includes ones already on `main` and can inflate the figure two- or three-fold. Only `+` lines count.
+- **Generated or vendored output.** A committed bundle or lockfile swamps the ratio in both directions — exclude it and measure the hand-written slice.
+- **Stacked branches.** A PR stacked on another inherits its comments, so measure against the parent branch rather than `main`, or the shared lines are counted twice.
+
+**Legitimate exceptions, named rather than assumed**: a constants or config file, where the values *are* the content and the only thing unrecoverable from the code is why each holds that value; and any small file, where a handful of necessary notes over a few dozen lines of code prices in high. Say which applies; don't let "config files run higher" become a blanket excuse.
+
+**Fix stale comments adjacent to your diff.** The rules cover the comments your change sits among, not only the lines you added: the block above the function you edited, the note beside the line you moved, the comment inside the hunk. If it restates the code, runs past 2 lines, or has rotted out of sync with the code, fix or delete it while you are there — and **delete commented-out code on sight**, since version control already keeps it and nobody will uncomment it.
+
+Scope this tightly: **adjacent to the diff, not the whole file.** A stale comment at the other end of a file you happened to touch is somebody else's change. This is a narrow carve-out from "don't touch what you weren't asked to touch" (`CLAUDE.md` core principles) — that rule exists to prevent unrelated drive-by refactors, not to preserve rot in the lines you are already rewriting. Put the cleanup in its own commit so the functional diff stays readable.
 
 ```go
 // Bad: six lines restating the code and narrating the decision

--- a/skills/git-commit/SKILL.md
+++ b/skills/git-commit/SKILL.md
@@ -54,7 +54,7 @@ Before every commit, enter a review loop (same discipline as the plan review loo
 - **Test coverage & edge cases** — are the new paths actually exercised, including boundaries, error paths, and the contract (not just the happy path)?
 - **Security** — beyond OWASP basics: trust boundaries, authz on every new path, secret handling, injection via every new input.
 - **Over-engineering & scope** — parameters with no caller, abstractions with one consumer, validation of unreachable states, machinery the current requirement doesn't need. Could a competent colleague have written this in half the lines? See the `coding-standards` skill ("Simplicity & Scope (YAGNI)").
-- **Comment accuracy & density** — do comments match the code, or did they rot during edits? Is the diff over-commented (restatements of the next line, rationale essays, review-round references)? See the `coding-standards` skill ("Comments").
+- **Comment accuracy & density** — do comments match the code, or did they rot during edits? Is the diff over-commented (restatements of the next line, rationale essays, review-round references)? **Measure it, don't eyeball it**: run the one-liner in the `coding-standards` skill ("Comments") and check the two per-comment rules — nothing over 2 lines, nothing describing what the code does. Over ~15% means delete until under it or name the exception.
 - **Performance & resources** — N+1s, unbounded growth, leaked handles/goroutines, needless allocation on hot paths.
 - **API, naming & convention consistency** — does it match the surrounding code's idiom, naming, and the project's documented conventions?
 


### PR DESCRIPTION
## What

Makes the comment budget something you can actually check, and says what to do about comments that were already there.

- Promotes the two **per-comment** rules to hard constraints: nothing over 2 lines, nothing describing what the code does.
- Adds the exact measurement one-liner, and names the three ways the ratio lies.
- Requires the number be stated in the PR description or pre-commit self-check.
- Names the legitimate exceptions instead of a blanket "config files run higher".
- Narrow carve-out for stale comments **adjacent to the diff**.

## Why

The budget was "a guideline for self-checking, not a hard gate", with no stated way to measure it. It was therefore never measured, and the number got quoted from impression.

**Ratios alone don't bite.** A diff can sit comfortably under 15% and still be full of three-line restatements. What catches those is per-comment and checkable one comment at a time.

## The three lying modes, all observed this week

| | effect |
|---|---|
| **Whole-file counts** instead of added lines | one PR reported at **175** comment lines; its own contribution was **71** — quoted to the repo owner before being caught |
| **Generated output** in the diff | a PR that was 95% a committed `ncc` bundle showed a meaningless 29%; its hand-written slice was 13% |
| **Stacked branches** | a stacked PR inherits its parent's comments — ~half of one PR's 196 were its parent's, counted twice |

The first one is why this PR exists: I mis-reported the number myself, from the wrong measurement, and only caught it when asked to justify it.

## Pre-existing comments

The rules read as applying to added lines, so a cleanup pass legitimately left a **39-line commented-out config block** in a file it was otherwise heavily editing, citing "don't touch what you weren't asked to touch".

That exemption exists to stop unrelated drive-by refactors, not to preserve rot in the lines being rewritten. The carve-out is deliberately narrow: **adjacent to the diff** — the block above the function you edited, the note beside the line you moved — and commented-out code deleted on sight. A stale comment at the far end of a touched file is somebody else's change. Cleanup goes in its own commit so the functional diff stays readable.

## Scope

23 added lines across two skills.

Closes #56
