### PR TITLE
chore(gitignore): ignore worktrees/ under the config dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,7 +65,9 @@ RTK.md
 
 # Git worktrees checked out under the config dir — these are working copies of OTHER repos,
 # not content of this one. Ignored so `git add -A` can never try to swallow them.
-worktrees/
+# Anchored with a leading slash: an unanchored `worktrees/` would match at any depth and would
+# silently swallow a future `skills/worktrees/` too.
+/worktrees/
 
 # macOS junk
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -63,5 +63,9 @@ RTK.md
 # Editor / shell / settings backups — never tracked
 *.bak
 
+# Git worktrees checked out under the config dir — these are working copies of OTHER repos,
+# not content of this one. Ignored so `git add -A` can never try to swallow them.
+worktrees/
+
 # macOS junk
 .DS_Store


### PR DESCRIPTION
`worktrees/` holds git worktree checkouts of **other** repositories (currently 337 MB across `feedfwd-pr1/` and `feedfwd-unit-d/`), not content of this repo. It was untracked and unignored, so any `git add -A` here would try to swallow it — which nearly happened during the skills refactor.

Ignoring only. Nothing is deleted or moved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added `worktrees/` to ignored files, preventing external repository working copies from appearing as untracked project files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->