### PR TITLE
feat(scripts): extract the triage label set into a runnable bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ successor skills, so older references keep resolving.
 |------|---------|
 | [`scripts/setup-agent-symlinks.sh`](scripts/setup-agent-symlinks.sh) | Link each skill into `~/.agents/skills/` (read by Codex and Gemini) and the root config into `~/.codex` and `~/.gemini`. |
 | [`scripts/validate-skills.sh`](scripts/validate-skills.sh) | Pre-commit check that every skill stays discoverable by all three tools. |
+| [`scripts/bootstrap-triage-labels.sh`](scripts/bootstrap-triage-labels.sh) | Create the full triage-rubric label set in a repo, once, before its first triage pass. Idempotent; never deletes a label. |
 | [`agents/`](agents/) | Submodule pointing to [`contains-studio/agents`](https://github.com/contains-studio/agents) — a curated agent library. |
 | [`local-paths.md.example`](local-paths.md.example) | Template for `local-paths.md`, per-machine paths and tool locations referenced from the rule files (e.g. graphify CLI / venv). |
 | [`projects.md.example`](projects.md.example) | Template for `projects.md`, the personal index of projects Claude should know about. |

--- a/scripts/bootstrap-triage-labels.sh
+++ b/scripts/bootstrap-triage-labels.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Create the full triage-rubric label set in a repository, once, before the first triage pass.
+# This is the executable form of the label set documented in skills/triage-labels/SKILL.md
+# ("Default label set") — that skill is the rationale, this file is the thing you run.
+#
+# Usage:
+#   scripts/bootstrap-triage-labels.sh              # current repo (from cwd)
+#   scripts/bootstrap-triage-labels.sh owner/repo   # a specific repo
+#
+# Idempotent: uses `gh label create --force`, so re-running updates colours and descriptions on
+# labels that already exist rather than failing. It only ever creates or updates — it never deletes
+# a label, including ones not in this set.
+#
+# Before running in a repo that already has a scheme, check `gh label list --limit 200` and skip the
+# dimensions it already covers under different names. Conforming beats fragmenting: if a project
+# uses `Pri-Critical` instead of `priority/p0`, keep theirs.
+set -uo pipefail
+
+repo_args=()
+if [ "$#" -gt 1 ]; then
+  echo "usage: $(basename "$0") [owner/repo]" >&2
+  exit 2
+elif [ "$#" -eq 1 ]; then
+  repo_args=(--repo "$1")
+fi
+
+failures=0
+
+label() {
+  name="$1"; color="$2"; desc="$3"
+  if gh label create "$name" --color "$color" --description "$desc" --force "${repo_args[@]+"${repo_args[@]}"}" >/dev/null 2>&1; then
+    echo "ok: $name"
+  else
+    echo "FAILED: $name" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+# Status (procedural)
+label "triaged"                 "0e8a16" "Item has been triaged"
+label "status/blocked"          "b60205" "Blocked on something external"
+label "status/needs-info"       "fbca04" "Awaiting clarification from the asker"
+label "status/stale-candidate"  "cccccc" "Flagged for the next stale sweep"
+label "status/wontdo"           "ededed" "Closed as not-planned"
+
+# Priority (derived — see the rubric in the skill)
+label "priority/p0" "b60205" "Drop everything; same-day fix"
+label "priority/p1" "d93f0b" "Next up; this sprint"
+label "priority/p2" "fbca04" "Backlog-worthy"
+label "priority/p3" "c5def5" "Polish / idea / may never ship"
+
+# Severity (independent of how often)
+label "severity/critical" "b60205" "Major harm when it happens"
+label "severity/high"     "d93f0b" "Significant harm"
+label "severity/medium"   "fbca04" "Moderate harm"
+label "severity/low"      "c5def5" "Minor harm"
+
+# Urgency
+label "urgency/now"          "b60205" "Drop other things"
+label "urgency/this-sprint"  "d93f0b" "Within the current sprint"
+label "urgency/this-quarter" "fbca04" "Within the quarter"
+label "urgency/eventually"   "c5def5" "No deadline"
+
+# Impact (audience size + blast radius)
+label "impact/all-users" "b60205" "Affects every user"
+label "impact/many"      "d93f0b" "Affects most users"
+label "impact/few"       "fbca04" "Limited audience"
+label "impact/internal"  "c5def5" "Team-internal only"
+
+# Effort
+label "effort/xs" "c5def5" "Trivial / one-liner"
+label "effort/s"  "c5def5" "Hours"
+label "effort/m"  "fbca04" "Days"
+label "effort/l"  "d93f0b" "Weeks"
+label "effort/xl" "b60205" "Multi-week / refactor"
+
+# Type
+label "type/bug"      "ee0701" "Defect"
+label "type/feat"     "0e8a16" "New capability"
+label "type/chore"    "c5def5" "Maintenance / non-user-visible"
+label "type/docs"     "0075ca" "Documentation"
+label "type/security" "b60205" "Security finding"
+label "type/question" "d876e3" "Question for the project / asker"
+
+if [ "$failures" -gt 0 ]; then
+  echo "$failures label(s) failed - check 'gh auth status' and repo write access" >&2
+  exit 1
+fi
+
+echo "triage label set bootstrapped"

--- a/skills/triage-labels/SKILL.md
+++ b/skills/triage-labels/SKILL.md
@@ -84,55 +84,17 @@ gh issue close   <num> --reason "not planned" --comment "Duplicate of #X — clo
 gh issue close   <num> --reason completed     --comment "Answered above — closing. Reopen if still ambiguous."
 ```
 
-Pre-create missing labels once per repo. Full bootstrap (covers the entire rubric — run idempotently with `--force` to update colours/descriptions on re-run):
+Pre-create missing labels once per repo with **`scripts/bootstrap-triage-labels.sh`** (in this
+repo), which creates the entire rubric below in one pass:
 
 ```sh
-# Status (procedural)
-gh label create "triaged"                 --color "0e8a16" --description "Item has been triaged" --force
-gh label create "status/blocked"          --color "b60205" --description "Blocked on something external" --force
-gh label create "status/needs-info"       --color "fbca04" --description "Awaiting clarification from the asker" --force
-gh label create "status/stale-candidate"  --color "cccccc" --description "Flagged for the next stale sweep" --force
-gh label create "status/wontdo"           --color "ededed" --description "Closed as not-planned" --force
-
-# Priority (derived — see rubric)
-gh label create "priority/p0" --color "b60205" --description "Drop everything; same-day fix" --force
-gh label create "priority/p1" --color "d93f0b" --description "Next up; this sprint" --force
-gh label create "priority/p2" --color "fbca04" --description "Backlog-worthy" --force
-gh label create "priority/p3" --color "c5def5" --description "Polish / idea / may never ship" --force
-
-# Severity (independent of how often)
-gh label create "severity/critical" --color "b60205" --description "Major harm when it happens" --force
-gh label create "severity/high"     --color "d93f0b" --description "Significant harm" --force
-gh label create "severity/medium"   --color "fbca04" --description "Moderate harm" --force
-gh label create "severity/low"      --color "c5def5" --description "Minor harm" --force
-
-# Urgency
-gh label create "urgency/now"          --color "b60205" --description "Drop other things" --force
-gh label create "urgency/this-sprint"  --color "d93f0b" --description "Within the current sprint" --force
-gh label create "urgency/this-quarter" --color "fbca04" --description "Within the quarter" --force
-gh label create "urgency/eventually"   --color "c5def5" --description "No deadline" --force
-
-# Impact (audience size + blast radius)
-gh label create "impact/all-users" --color "b60205" --description "Affects every user" --force
-gh label create "impact/many"      --color "d93f0b" --description "Affects most users" --force
-gh label create "impact/few"       --color "fbca04" --description "Limited audience" --force
-gh label create "impact/internal"  --color "c5def5" --description "Team-internal only" --force
-
-# Effort
-gh label create "effort/xs" --color "c5def5" --description "Trivial / one-liner" --force
-gh label create "effort/s"  --color "c5def5" --description "Hours" --force
-gh label create "effort/m"  --color "fbca04" --description "Days" --force
-gh label create "effort/l"  --color "d93f0b" --description "Weeks" --force
-gh label create "effort/xl" --color "b60205" --description "Multi-week / refactor" --force
-
-# Type
-gh label create "type/bug"      --color "ee0701" --description "Defect" --force
-gh label create "type/feat"     --color "0e8a16" --description "New capability" --force
-gh label create "type/chore"    --color "c5def5" --description "Maintenance / non-user-visible" --force
-gh label create "type/docs"     --color "0075ca" --description "Documentation" --force
-gh label create "type/security" --color "b60205" --description "Security finding" --force
-gh label create "type/question" --color "d876e3" --description "Question for the project / asker" --force
+scripts/bootstrap-triage-labels.sh              # the repo you are standing in
+scripts/bootstrap-triage-labels.sh owner/repo   # a specific repo
 ```
+
+It uses `gh label create --force`, so re-running updates colours and descriptions rather than
+failing, and it only ever creates or updates - it never deletes a label, including ones outside this
+set. The script is the single definition of the label set; this section is the rationale for it.
 
 Skip dimensions the project already covers under different names — don't fragment. If the project uses `Pri-Critical` instead of `priority/p0`, conform.
 


### PR DESCRIPTION
## What

The `triage-labels` skill carried the whole rubric as ~40 lines of inline `gh label create` calls inside a code fence — the thing you actually want to *run*, formatted as something you have to copy out by hand. It becomes `scripts/bootstrap-triage-labels.sh`, taking an optional `owner/repo`.

```sh
scripts/bootstrap-triage-labels.sh              # the repo you are standing in
scripts/bootstrap-triage-labels.sh owner/repo   # a specific repo
```

## Extracted, not duplicated

The skill's block was already the canonical definition of the set, so adding a script *alongside* it would have left two copies to drift apart. The skill now points at the script and keeps the rationale (what each dimension means, the priority rubric, when to conform to a project's existing scheme); the script is the single definition of the labels themselves.

## Safety

Keeps `--force`, so re-running updates colours and descriptions rather than failing. It only ever creates or updates — **it never deletes a label**, including ones outside this set. Guidance to check `gh label list` first and conform to an existing scheme rather than fragment is retained in the skill.

## Verification

Run against this repo, which previously defined only `effort/xs|s`, `severity/low`, `priority/p3`, `urgency/eventually` and `impact/internal` — so the rubric the `triage-labels` skill assumes could not actually be applied here. All 33 labels now exist, and a second run was a clean no-op update.

`scripts/validate-skills.sh` passes (5404/7000 chars).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a script to create or update the complete triage label set for the current or specified repository.
  * Reports the status of each label operation and clearly indicates failures.

* **Documentation**
  * Updated the README and triage-label guidance with instructions for using the new script.
  * Clarified that existing labels are preserved and no labels are deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->