### PR TITLE
docs(readme): point Customizing at the skills, not the stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,10 @@ successor skills, so older references keep resolving.
 
 ## Customizing
 
-Everything here is opinion, not gospel. The rules in `CLAUDE.md` and its referenced files are instructions to Claude — edit them to match how you work.
+Everything here is opinion, not gospel. The rules in `CLAUDE.md` and the skills are instructions to Claude — edit them to match how you work.
 
-- Change the preferred stack in `coding-standards.md`.
-- Adjust the commit conventions in `git-workflow.md`.
+- Change the preferred stack in [`skills/coding-standards/SKILL.md`](skills/coding-standards/SKILL.md).
+- Adjust the commit conventions in [`skills/git-commit/SKILL.md`](skills/git-commit/SKILL.md).
 - Swap out the agent submodule in `.gitmodules` for a different library, or vendor your own agents into `agents/`.
 - Add your own skills under `skills/<name>/SKILL.md` — they become `/name` in Claude, `$name` in
   Codex, and implicitly activatable in Gemini. Run `scripts/validate-skills.sh` before committing.


### PR DESCRIPTION
Two references in the README's Customizing list survived the skills refactor pointing at the old flat files:

- "Change the preferred stack in `coding-standards.md`" → that path is now a three-line pointer stub, so a reader following it finds a redirect instead of the content.
- "Adjust the commit conventions in `git-workflow.md`" → that file no longer exists as a unit at all; commit conventions live in the `git-commit` skill.

Both now link into `skills/`.

These were misses in the refactor's own cross-reference pass, which swept `skills/` and `CLAUDE.md` but not the README's prose. A full re-scan of the repo for stale references to the eleven moved docs found no others outside the two autopilot routine prompts, which intentionally use file paths because the remote agents that read them have no skill system.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated customization guidance to reference `CLAUDE.md` and skill-specific `SKILL.md` files.
  * Removed references to legacy flat documentation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->